### PR TITLE
Corrected issue with /etc/init.d/supervisord script + some minor adjustments

### DIFF
--- a/files/Debian.supervisord
+++ b/files/Debian.supervisord
@@ -29,7 +29,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/bin/supervisord
-SUPERVISORCTL=/usr/bin/supervisorctl
+SUPERVISORCTL=/usr/local/bin/supervisorctl
 NAME=supervisord
 DESC=supervisor
 

--- a/files/Debian.supervisord
+++ b/files/Debian.supervisord
@@ -28,7 +28,7 @@
 . /lib/lsb/init-functions
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/supervisord
+DAEMON=/usr/local/bin/supervisord
 SUPERVISORCTL=/usr/bin/supervisorctl
 NAME=supervisord
 DESC=supervisor

--- a/files/Debian.supervisord
+++ b/files/Debian.supervisord
@@ -1,14 +1,18 @@
 #! /bin/sh
 #
-# skeleton      example file to build /etc/init.d/ scripts.
-#               This file should be used to construct scripts for /etc/init.d.
+# Downloaded from:
+# http://bazaar.launchpad.net/~ubuntu-branches/ubuntu/trusty/supervisor/trusty/view/head:/debian/supervisor.init
 #
-#               Written by Miquel van Smoorenburg <miquels@cistron.nl>.
-#               Modified for Debian
-#               by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+# skeleton  example file to build /etc/init.d/ scripts.
+#       This file should be used to construct scripts for /etc/init.d.
+#
+#       Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+#       Modified for Debian
+#       by Ian Murdock <imurdock@gnu.ai.mit.edu>.
 #               Further changes by Javier Fernandez-Sanguino <jfs@debian.org>
+#               Modified by sbilly <superli.1980@gmail.com> Added supervisorctl to status
 #
-# Version:      @(#)skeleton  1.9  26-Feb-2001  miquels@cistron.nl
+# Version:  @(#)skeleton  1.9  26-Feb-2001  miquels@cistron.nl
 #
 ### BEGIN INIT INFO
 # Provides:          supervisor
@@ -21,11 +25,13 @@
 #                    subprocesses.
 ### END INIT INFO
 
+. /lib/lsb/init-functions
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/local/bin/supervisord
+DAEMON=/usr/bin/supervisord
+SUPERVISORCTL=/usr/bin/supervisorctl
 NAME=supervisord
-DESC=supervisord
+DESC=supervisor
 
 test -x $DAEMON || exit 0
 
@@ -38,8 +44,9 @@ DODTIME=5                   # Time to wait for the server to die, in seconds
 
 # Include supervisor defaults if available
 if [ -f /etc/default/supervisor ] ; then
-        . /etc/default/supervisor
+    . /etc/default/supervisor
 fi
+DAEMON_OPTS="-c /etc/supervisor/supervisord.conf $DAEMON_OPTS"
 
 set -e
 
@@ -78,7 +85,7 @@ force_stop() {
             kill -9 $pid
             [ -n "$DODTIME" ] && sleep "$DODTIME"s
             if running ; then
-                echo "Cannot kill $LABEL (pid=$pid)!"
+                echo "Cannot kill $NAME (pid=$pid)!"
                 exit 1
             fi
         fi
@@ -89,78 +96,78 @@ force_stop() {
 
 case "$1" in
   start)
-        echo -n "Starting $DESC: "
-        start-stop-daemon --start --quiet --pidfile $PIDFILE \
-                --exec $DAEMON -- $DAEMON_OPTS
-        test -f $PIDFILE || sleep 1
+    echo -n "Starting $DESC: "
+    start-stop-daemon --start --quiet --pidfile $PIDFILE \
+        --startas $DAEMON -- $DAEMON_OPTS
+    test -f $PIDFILE || sleep 1
         if running ; then
             echo "$NAME."
         else
             echo " ERROR."
         fi
-        ;;
+    ;;
   stop)
-        echo -n "Stopping $DESC: "
-        start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
-        echo "$NAME."
-        ;;
+    echo -n "Stopping $DESC: "
+    start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+    echo "$NAME."
+    ;;
   force-stop)
-        echo -n "Forcefully stopping $DESC: "
+    echo -n "Forcefully stopping $DESC: "
         force_stop
         if ! running ; then
             echo "$NAME."
         else
             echo " ERROR."
         fi
-        ;;
+    ;;
   #reload)
-        #
-        #       If the daemon can reload its config files on the fly
-        #       for example by sending it SIGHUP, do it here.
-        #
-        #       If the daemon responds to changes in its config file
-        #       directly anyway, make this a do-nothing entry.
-        #
-        # echo "Reloading $DESC configuration files."
-        # start-stop-daemon --stop --signal 1 --quiet --pidfile \
-        #       /var/run/$NAME.pid --exec $DAEMON
+    #
+    #   If the daemon can reload its config files on the fly
+    #   for example by sending it SIGHUP, do it here.
+    #
+    #   If the daemon responds to changes in its config file
+    #   directly anyway, make this a do-nothing entry.
+    #
+    # echo "Reloading $DESC configuration files."
+    # start-stop-daemon --stop --signal 1 --quiet --pidfile \
+    #   /var/run/$NAME.pid --exec $DAEMON
   #;;
   force-reload)
-        #
-        #       If the "reload" option is implemented, move the "force-reload"
-        #       option to the "reload" entry above. If not, "force-reload" is
-        #       just the same as "restart" except that it does nothing if the
-        #   daemon isn't already running.
-        # check wether $DAEMON is running. If so, restart
-        start-stop-daemon --stop --test --quiet --pidfile \
-                /var/run/$NAME.pid --exec $DAEMON \
-        && $0 restart \
-        || exit 0
-        ;;
+    #
+    #   If the "reload" option is implemented, move the "force-reload"
+    #   option to the "reload" entry above. If not, "force-reload" is
+    #   just the same as "restart" except that it does nothing if the
+    #   daemon isn't already running.
+    # check wether $DAEMON is running. If so, restart
+    start-stop-daemon --stop --test --quiet --pidfile $PIDFILE \
+        --startas $DAEMON \
+    && $0 restart \
+    || exit 0
+    ;;
   restart)
     echo -n "Restarting $DESC: "
-        start-stop-daemon --stop --quiet --pidfile \
-                /var/run/$NAME.pid --exec $DAEMON
-        [ -n "$DODTIME" ] && sleep $DODTIME
-        start-stop-daemon --start --quiet --pidfile \
-                /var/run/$NAME.pid --exec $DAEMON -- $DAEMON_OPTS
-        echo "$NAME."
-        ;;
+    start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+    [ -n "$DODTIME" ] && sleep $DODTIME
+    start-stop-daemon --start --quiet --pidfile $PIDFILE \
+        --startas $DAEMON -- $DAEMON_OPTS
+    echo "$NAME."
+    ;;
   status)
-    echo -n "$LABEL is "
+    echo -n "$NAME is "
     if running ;  then
         echo "running"
     else
         echo " not running."
         exit 1
     fi
+    $SUPERVISORCTL $DAEMON_OPTS status
     ;;
   *)
-        N=/etc/init.d/$NAME
-        # echo "Usage: $N {start|stop|restart|reload|force-reload}" >&2
-        echo "Usage: $N {start|stop|restart|force-reload|status|force-stop}" >&2
-        exit 1
-        ;;
+    N=/etc/init.d/$NAME
+    # echo "Usage: $N {start|stop|restart|reload|force-reload}" >&2
+    echo "Usage: $N {start|stop|restart|force-reload|status|force-stop}" >&2
+    exit 1
+    ;;
 esac
 
 exit 0

--- a/files/Debian.supervisord
+++ b/files/Debian.supervisord
@@ -46,7 +46,7 @@ DODTIME=5                   # Time to wait for the server to die, in seconds
 if [ -f /etc/default/supervisor ] ; then
     . /etc/default/supervisor
 fi
-DAEMON_OPTS="-c /etc/supervisor/supervisord.conf $DAEMON_OPTS"
+#DAEMON_OPTS="-c /etc/supervisor/supervisord.conf $DAEMON_OPTS"
 
 set -e
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,12 +4,13 @@
 #   include supervisor
 #
 #   class { 'supervisor':
+#     version                 => '3.1.3',
 #     include_superlance      => false,
 #     enable_http_inet_server => true,
 #   }
 
 class supervisor (
-  $version                  = '3.1.2',
+  $version                  = '3.1.3',
   $include_superlance       = true,
   $enable_http_inet_server  = false,
 ) {
@@ -35,7 +36,7 @@ class supervisor (
   package { $pkg_setuptools: ensure => installed, }
 
   package { 'supervisor':
-    ensure   => '3.1.3',
+    ensure   => $version,
     provider => 'pip'
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class supervisor (
   package { $pkg_setuptools: ensure => installed, }
 
   package { 'supervisor':
-    ensure   => '3.1.2',
+    ensure   => '3.1.3',
     provider => 'pip'
   }
 

--- a/manifests/program.pp
+++ b/manifests/program.pp
@@ -89,7 +89,7 @@ define supervisor::program (
     notify  => Exec['supervisor::update'],
   }
 
-  # easy_install behaves differently in adding binary path
+  # Adapt binary path depending on osfamily
   case $::osfamily {
     redhat: {
       $path_bin = '/usr/bin'


### PR DESCRIPTION
Updated to last version available (3.1.3) …
    
    See https://pypi.python.org/simple/supervisor/

Corrected issue with "service supervisor restart" :
    
    => Failed to call refresh: Could not restart Service[supervisord]: Execution of '/etc/init.d/supervisord restart' returned 1: Restarting supervisord:
    
    Used last version of init script available from https://github.com/Supervisor/initscripts/blob/master/ubuntu
    Corrected supervisord path
    Removed use of supervisors.conf in init script

Permitted to give supervisor version as param (job was already half done)
Corrected comment because easy install is no more used