### PR TITLE
fix > enable changed 'false' to 'true'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,7 @@ class supervisor (
     ensure     => running,
     enable     => true,
     hasrestart => true,
+    provider   => init,
     require    => File["${path_config}/supervisord.conf"],
   }
 


### PR DESCRIPTION
In centos 7 default service provider is 'systemd', but in this module we use init script