### PR TITLE
Add config file path for remove warning on start supervisord

### DIFF
--- a/files/RedHat.supervisord
+++ b/files/RedHat.supervisord
@@ -20,7 +20,7 @@ RETVAL=0
 
 start() {
   echo -n $"Starting supervisord: "
-  daemon supervisord
+  daemon supervisord -c /etc/supervisord.conf
   RETVAL=$?
   echo
   [ $RETVAL -eq 0 ] && touch /var/lock/subsys/supervisord


### PR DESCRIPTION
When i will restart the supervisord process, i have this error on start:

"Iniciando o supervisord: /usr/lib/python2.6/site-packages/supervisor/options.py:296: UserWarning: Supervisord is running as root and it is searching for its configuration file in default locations (including its current working directory); you probably want to specify a "-c" argument specifying an absolute path to a configuration file for improved security.
  'Supervisord is running as root and it is searching '"

This error ocourr because in startup script missing de config file path (-c /etc/supervisord.conf), so i add the param in "RedHat.supervisord".

Thank you
