### PR TITLE
update metadata, add missing dependencies section

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,19 +7,41 @@
   "source": "https://github.com/proletaryo/puppet-supervisor",
   "project_page": "https://forge.puppetlabs.com/proletaryo/supervisor",
   "issues_url": "https://github.com/proletaryo/puppet-supervisor/issues",
-  "tags": ["supervisor", "process control", "process management", "awslinux" ],
+  "tags": [
+    "supervisor",
+    "process control",
+    "process management",
+    "awslinux"
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Amazon",
-      "operatingsystemrelease":[ "2014.09", "2015.03" ]
+      "operatingsystemrelease": [
+        "2014.09",
+        "2015.03"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [ "6.4" ]
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "12.04" ]
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04"
+      ]
     }
-   ]
+  ],
+  "dependencies": []
 }


### PR DESCRIPTION
I'm guessing this would work on Ubuntu 14 and CentOS 7, though could remove them if you want.
The missing dependencies section is causing some issues, and I think `operatingsystemrelease` should be major release number only