### PR TITLE
Removing warning message on RedHat-based operating because of installing an obsolete pip package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,12 @@ class supervisor (
         $path_config    = '/etc'
       }
       else {
-        $pkg_setuptools = 'python-pip'
+        if (versioncmp($::operatingsystemmajrelease, '6') == 1 ) {
+          $pkg_setuptools = 'python2-pip'
+        }
+        else {
+          $pkg_setuptools = 'python-pip'
+        }
         $path_config    = '/etc'
       }
     }


### PR DESCRIPTION
On CentOS 7 on every puppet run I see the following warning message:

```
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for server.example.com
Info: Applying configuration version '1535727032'
Notice: /Stage[main]/Supervisor/Package[python-pip]/ensure: created
^^^
Notice: Applied catalog in 19.00 seconds
```

The underlying problem is that on CentOS (RHEL) 7 the `python-pip` package has been marked as obsolete:

```
[root@server.example.com ~]# yum install python-pip
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
Package python-pip-7.1.0-1.el7.noarch is obsoleted by python2-pip-8.1.2-6.el7.noarch which is already installed
Nothing to do
```

This warning message _isn't_ a huge problem, the intention was to make the output more clean.